### PR TITLE
Add control to the files that are copied into the Ruby project public folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ repos/*
 .DS_Store
 vendor/bundler/*
 vendor/bundle/*
+.idea
+

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ app_root/
 In addition to the above configuration, the following optional configuration is available
 
 ```
-"filesToMove": ["js/*.js", "css/*.css"]  # Which files to move into the target directory
-"createDirectories": false               # Create target directories if they don't exist
+"filesToDeploy": ["js/*.js", "css/*.css"]  # Which files to move into the target directory
+"overwriteExistingFiles": true             # Whether to overwrite files in the target directory with files from dist
 ```
 
 ### Future Times

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The apps are stored in directories off the root of the repo called "front_end1" 
 
 ### Gritty Details
 
-In the above configuration, this buildpack installs lineman, runs lineman build, and looks for the following
+In the default configuration, this buildpack installs lineman, runs lineman build, and looks for the following
 
 ```
 app_root/
@@ -62,6 +62,14 @@ app_root/
         app2/
             js/
             css/
+```
+
+### Additional configuration
+In addition to the above configuration, the following optional configuration is available
+
+```
+"filesToMove": ["js/*.js", "css/*.css"]  # Which files to move into the target directory
+"createDirectories": false               # Create target directories if they don't exist
 ```
 
 ### Future Times

--- a/bin/compile
+++ b/bin/compile
@@ -49,11 +49,12 @@ class BuildLinemanApps
   def linemen(config)
     config.fetch("linemanApps").each do |app|
       location = app.fetch("location")
-      filesToMove = app.fetch("filesToMove", ["js/*.js", "css/*.css"])
-      createDirectories = app.fetch("createDirectories", false)
+      filesToDeploy = app.fetch("filesToDeploy", ["*"])
+      overwriteFiles= app.fetch("overwriteExistingFiles", true)
+
       raise "No Lineman App at #{location}" unless Dir.exist? lineman_path(location)
       build_lineman location
-      move_assets app.fetch("installToPath"), location, filesToMove, createDirectories
+      move_assets app.fetch("installToPath"), location, filesToDeploy, overwriteFiles
     end
   end
 
@@ -96,13 +97,14 @@ class BuildLinemanApps
     puts run("mv #{path}/node_modules #{cached_modules_path}")
   end
 
-  def move_assets destination, origin, filesToMove, createDirectories
-    raise "Asset destination expected but missing at #{destination}" unless createDirectories or Dir.exist? destination
+  def move_assets destination, origin, filesToDeploy, overwriteFiles
     path = lineman_path(origin)
-    filesToMove.each do |files|
+    filesToDeploy.each do |files|
       dirName = File.dirname files
-      create_recursive dirName, destination if createDirectories
-      puts run("mv #{path}/dist/#{files} #{destination}/#{dirName}/")
+      create_recursive dirName, destination
+      no_overwrite = overwriteFiles ? '' : '-n'
+
+      puts run("mv -f -v #{no_overwrite} #{path}/dist/#{files} #{destination}/#{dirName}/")
     end
   end
 

--- a/bin/compile
+++ b/bin/compile
@@ -5,6 +5,7 @@ $stdout.sync = true
 
 $:.unshift File.expand_path("../../lib", __FILE__)
 require "language_pack"
+require "fileutils"
 
 if pack = LanguagePack.detect(ARGV[0], ARGV[1])
   pack.log("compile") do
@@ -48,9 +49,11 @@ class BuildLinemanApps
   def linemen(config)
     config.fetch("linemanApps").each do |app|
       location = app.fetch("location")
+      filesToMove = app.fetch("filesToMove", ["js/*.js", "css/*.css"])
+      createDirectories = app.fetch("createDirectories", false)
       raise "No Lineman App at #{location}" unless Dir.exist? lineman_path(location)
       build_lineman location
-      move_assets app.fetch("installToPath"), location
+      move_assets app.fetch("installToPath"), location, filesToMove, createDirectories
     end
   end
 
@@ -93,11 +96,18 @@ class BuildLinemanApps
     puts run("mv #{path}/node_modules #{cached_modules_path}")
   end
 
-  def move_assets destination, origin
-    raise "Asset destination expected but missing at #{destination}" unless Dir.exist? destination
+  def move_assets destination, origin, filesToMove, createDirectories
+    raise "Asset destination expected but missing at #{destination}" unless createDirectories or Dir.exist? destination
     path = lineman_path(origin)
-    puts run("mv #{path}/dist/js/*.js #{destination}/js/")
-    puts run("mv #{path}/dist/css/*.css #{destination}/css/")
+    filesToMove.each do |files|
+      dirName = File.dirname files
+      create_recursive dirName, destination if createDirectories
+      puts run("mv #{path}/dist/#{files} #{destination}/#{dirName}/")
+    end
+  end
+
+  def create_recursive path, location
+    FileUtils.mkpath File.join(location, path)
   end
 end
 

--- a/bin/compile
+++ b/bin/compile
@@ -104,7 +104,7 @@ class BuildLinemanApps
       create_recursive dirName, destination
       no_overwrite = overwriteFiles ? '' : '-n'
 
-      puts run("mv -f -v #{no_overwrite} #{path}/dist/#{files} #{destination}/#{dirName}/")
+      puts run("mv -f #{no_overwrite} #{path}/dist/#{files} #{destination}/#{dirName}/")
     end
   end
 


### PR DESCRIPTION
Added two configuration items to lineman.json

```
{"linemanApps":
[
    {
        "location": "front_end",
        "installToPath": "public",
        "filesToMove": ["js/*.js", "css/*.css", "img/*.*", "*.html"],
        "createDirectories": true
    }
]}
```

`filesToMove` contains a list of paths for files that need to be moved into the target folder.
`createDirectories` tells the compiler to create the target directories if they don't exist.

This allows to manage images and html assets in lineman as well.

Thanks,
Ariel Sakin
